### PR TITLE
Enable building with Bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -33,5 +33,11 @@ configure_make(
         "@libdb//:libdb",
         "@cajun-jsonapi//:cajun-jsonapi",
     ],
+    out_static_libs = [
+        "librepro.a"
+    ],
+    out_shared_libs = [
+        "librepro.so"
+    ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,5 +29,8 @@ configure_make(
         "all",
         "install",
     ],
+    deps = [
+        "@libdb//:libdb",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -26,7 +26,8 @@ configure_make(
     ],
     lib_source = ":resiprocate_srcs",
     targets = [
-        "all",
+        "clean",
+        "",
         "install",
     ],
     deps = [

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,6 +31,7 @@ configure_make(
     ],
     deps = [
         "@libdb//:libdb",
+        "@cajun-jsonapi//:cajun-jsonapi",
     ],
     visibility = ["//visibility:public"],
 )

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+
+# TODO break down sources into smaller parts and define relationships between them so that when building
+# RePro, only required sources are considered by Bazel
+filegroup(
+    name = "resiprocate_srcs",
+    srcs = glob([
+        "**"
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+configure_make(
+    name = "resiprocate",
+    autoreconf = True,
+    autoreconf_options = [
+        "--install"
+    ],
+    configure_in_place = True,
+    env = {
+        "CXXFLAGS": "-std=c++17"
+    },
+    configure_options = [
+        "--with-repro",
+    ],
+    lib_source = ":resiprocate_srcs",
+    targets = [
+        "all",
+        "install",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@ AM_MISSING_PROG([GPERF], [gperf])
 
 AC_GPERFVER
 
-AX_CXX_COMPILE_STDCXX(11)
+AX_CXX_COMPILE_STDCXX(17)
 
 AC_MSG_CHECKING([ for GNU warning flags])
 if test "${GXX}"x = yesx; then


### PR DESCRIPTION
- [x] Building with `repro`
- [x] Exporting all include headers
- [x] Exporting static and dynamic versions of libraries
- [ ] Use build outputs to compile and run external project executable

----

PR on pause due to difficulties when integrating build outputs with external project.

See also: https://github.com/zaleos/poc-resiprocate-2/pull/1